### PR TITLE
fix: plugin compatibility with Rollup Watch Mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,7 @@ const plugin: PluginImpl<{
           markoConfig
         ) as CompilationResult;
         compiledTemplates.set(id, compiled);
+        this.addWatchFile(id);
       }
 
       const { code, meta, map } = compiled;
@@ -237,7 +238,6 @@ const plugin: PluginImpl<{
     },
     generateBundle() {
       compiledTemplates.clear();
-      virtualFiles.clear();
     }
   };
 };


### PR DESCRIPTION
## Description

When using this plugin in Rollup Watch Mode ("rollup --watch"), I encountered two issues :
 - the virtualFiles (inline CSS mainly) are cleared at the end of the build and cannot be used for re-builds on file changes
 - the Marko templates are not being watched by Rollup as they need to be declared using ["this.addWatchFile(id: string)"](https://rollupjs.org/guide/en/#thisaddwatchfileid-string--void)

Note that :
 - on the contrary, the compiledTemplates must be cleared at the end of the build or they would never re-compile
 - the actual CSS files picked up by Marko don't need to be declared by this plugin, the PostCSS plugin does that

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
 ==> I didn't see any documentation that would need to change.

- [ ] I have added tests to cover my changes.
 ==> The tests are green, but there is no "Watch Mode" test, is it worth it ?
