### PR TITLE
fix: reduce unecessary client bundle runs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -353,8 +353,8 @@ function serverPlugin(opts: InternalOptions): rollup.Plugin {
           // the browser compilers what to bundle.
           const fileName = id.slice(SERVER_ENTRY_PREFIX.length);
           const entryId = toEntryId(fileName);
+          hasNewServerEntries ||= serverEntries[entryId] !== fileName;
           serverEntries[entryId] = fileName;
-          hasNewServerEntries = true;
           return getServerEntryTemplate({
             entryId,
             runtimeId: opts.markoConfig.runtimeId,


### PR DESCRIPTION
## Description

Fixes an issue where invalidating the server would unnecessarily invalidate the client build.

Resolves #12

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

