### PR TITLE
fix: issue with assets not being inlined with multi config

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -3,6 +3,7 @@ import path from "path";
 import * as rollup from "rollup";
 import css from "rollup-plugin-postcss";
 import { toMatchFile } from "jest-file-snapshot";
+import ".."; // Ensure jest watches changes to the plugin.
 
 const FIXTURES = path.join(__dirname, "fixtures");
 


### PR DESCRIPTION
## Description

Fixes an issue where only the first `browser` compiler was inlining assests into the server in a linked setup.

It works by having all browser compilers request the `bundleWriter` up front. This the bug by ensuring that all browser compilers are registered before any begin writing.

This PR also contains a fix & perf improvement for writing out the client manifest into the server bundle by using `appendFile` instead of `writeFile`.

## Motivation and Context
Resolves #21

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
